### PR TITLE
feat(repos): add popular repositories section with language colors

### DIFF
--- a/src/app/components/RepoList.tsx
+++ b/src/app/components/RepoList.tsx
@@ -1,0 +1,126 @@
+import { Repo } from '../interfaces/repo'
+import { getLanguageColor } from '../lib/language-colors'
+
+interface Props {
+  repos: Repo[]
+}
+
+function formatCount(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`
+  return String(n)
+}
+
+const RepoList = ({ repos }: Props) => {
+  if (repos.length === 0) return null
+
+  return (
+    <section className="mt-6 animate-card-enter">
+      <h3
+        className="text-lg font-semibold mb-4 px-1"
+        style={{ color: 'var(--color-text-primary)' }}
+      >
+        Popular Repositories
+      </h3>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {repos.map(repo => (
+          <a
+            key={repo.id}
+            href={repo.html_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="glass-card hover-surface rounded-xl p-5 flex flex-col gap-3 transition-all duration-200 group"
+          >
+            {/* Repo name */}
+            <div className="flex items-center gap-2 min-w-0">
+              <svg
+                width="16" height="16" viewBox="0 0 16 16"
+                style={{ fill: 'var(--color-text-muted)' }}
+                className="shrink-0"
+              >
+                <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z" />
+              </svg>
+              <span
+                className="font-medium text-sm truncate group-hover:underline"
+                style={{ color: 'var(--color-accent)' }}
+              >
+                {repo.name}
+              </span>
+            </div>
+
+            {/* Description */}
+            {repo.description && (
+              <p
+                className="text-xs leading-relaxed line-clamp-2"
+                style={{ color: 'var(--color-text-muted)' }}
+              >
+                {repo.description}
+              </p>
+            )}
+
+            {/* Topics */}
+            {repo.topics && repo.topics.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {repo.topics.slice(0, 3).map(topic => (
+                  <span
+                    key={topic}
+                    className="text-[10px] px-2 py-0.5 rounded-full"
+                    style={{
+                      backgroundColor: 'rgba(139, 92, 246, 0.12)',
+                      color: 'var(--color-accent)',
+                    }}
+                  >
+                    {topic}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Footer: language + stars + forks */}
+            <div className="flex items-center gap-4 mt-auto pt-1">
+              {repo.language && (
+                <span className="flex items-center gap-1.5 text-xs"
+                  style={{ color: 'var(--color-text-muted)' }}
+                >
+                  <span
+                    className="w-2.5 h-2.5 rounded-full inline-block"
+                    style={{ backgroundColor: getLanguageColor(repo.language) }}
+                  />
+                  {repo.language}
+                </span>
+              )}
+
+              {repo.stargazers_count > 0 && (
+                <span className="flex items-center gap-1 text-xs"
+                  style={{ color: 'var(--color-text-muted)' }}
+                >
+                  <svg width="14" height="14" viewBox="0 0 16 16"
+                    style={{ fill: 'var(--color-text-muted)' }}
+                  >
+                    <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
+                  </svg>
+                  {formatCount(repo.stargazers_count)}
+                </span>
+              )}
+
+              {repo.forks_count > 0 && (
+                <span className="flex items-center gap-1 text-xs"
+                  style={{ color: 'var(--color-text-muted)' }}
+                >
+                  <svg width="14" height="14" viewBox="0 0 16 16"
+                    style={{ fill: 'var(--color-text-muted)' }}
+                  >
+                    <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z" />
+                  </svg>
+                  {formatCount(repo.forks_count)}
+                </span>
+              )}
+            </div>
+          </a>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default RepoList

--- a/src/app/interfaces/repo.ts
+++ b/src/app/interfaces/repo.ts
@@ -1,0 +1,15 @@
+export interface Repo {
+  id: number
+  name: string
+  full_name: string
+  html_url: string
+  description: string | null
+  fork: boolean
+  language: string | null
+  stargazers_count: number
+  forks_count: number
+  watchers_count: number
+  open_issues_count: number
+  updated_at: string
+  topics: string[]
+}

--- a/src/app/lib/github.ts
+++ b/src/app/lib/github.ts
@@ -1,4 +1,5 @@
 import { User } from '../interfaces/user'
+import { Repo } from '../interfaces/repo'
 
 export type ErrorType = 'not_found' | 'rate_limit' | 'server_error' | 'network_error'
 
@@ -81,5 +82,21 @@ export async function fetchGitHubUser(username: string): Promise<GitHubResponse>
         resetAt: new Date(),
       },
     }
+  }
+}
+
+export async function fetchUserRepos(username: string): Promise<Repo[]> {
+  try {
+    const res = await fetch(
+      `https://api.github.com/users/${username}/repos?per_page=30&sort=updated`
+    )
+    if (!res.ok) return []
+    const repos: Repo[] = await res.json()
+    return repos
+      .filter(repo => !repo.fork)
+      .sort((a, b) => b.stargazers_count - a.stargazers_count)
+      .slice(0, 6)
+  } catch {
+    return []
   }
 }

--- a/src/app/lib/language-colors.ts
+++ b/src/app/lib/language-colors.ts
@@ -1,0 +1,35 @@
+export const languageColors: Record<string, string> = {
+  JavaScript: '#f1e05a',
+  TypeScript: '#3178c6',
+  Python: '#3572A5',
+  Java: '#b07219',
+  Go: '#00ADD8',
+  Rust: '#dea584',
+  'C++': '#f34b7d',
+  C: '#555555',
+  'C#': '#178600',
+  Ruby: '#701516',
+  PHP: '#4F5D95',
+  Swift: '#F05138',
+  Kotlin: '#A97BFF',
+  Dart: '#00B4AB',
+  HTML: '#e34c26',
+  CSS: '#563d7c',
+  SCSS: '#c6538c',
+  Shell: '#89e051',
+  Lua: '#000080',
+  Vue: '#41b883',
+  Svelte: '#ff3e00',
+  Elixir: '#6e4a7e',
+  Haskell: '#5e5086',
+  Scala: '#c22d40',
+  R: '#198CE7',
+  Jupyter: '#DA5B0B',
+  Dockerfile: '#384d54',
+  Markdown: '#083fa1',
+}
+
+export function getLanguageColor(language: string | null): string {
+  if (!language) return 'var(--color-text-muted)'
+  return languageColors[language] || 'var(--color-text-muted)'
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,11 +6,14 @@ import UserCardSkeleton from "./components/UserCardSkeleton"
 import EmptyState from "./components/EmptyState"
 import ErrorCard from "./components/ErrorCard"
 import RateLimitIndicator from "./components/RateLimitIndicator"
+import RepoList from "./components/RepoList"
 import { User } from '@/app/interfaces/user'
-import { fetchGitHubUser, GitHubError } from './lib/github'
+import { Repo } from '@/app/interfaces/repo'
+import { fetchGitHubUser, fetchUserRepos, GitHubError } from './lib/github'
 
 const Home = () => {
   const [user, setUser] = useState<User | null>(null)
+  const [repos, setRepos] = useState<Repo[]>([])
   const [error, setError] = useState<GitHubError | null>(null)
   const [loading, setLoading] = useState(false)
   const [hasSearched, setHasSearched] = useState(false)
@@ -33,10 +36,14 @@ const Home = () => {
 
     if (result.error) {
       setUser(null)
+      setRepos([])
       setError(result.error)
     } else if (result.user) {
       setUser(result.user)
       setError(null)
+
+      const userRepos = await fetchUserRepos(username)
+      setRepos(userRepos)
     }
 
     setLoading(false)
@@ -65,6 +72,7 @@ const Home = () => {
       {!loading && user && (
         <div key={user.login} className="animate-card-enter">
           <UserCardInfo user={user} />
+          <RepoList repos={repos} />
         </div>
       )}
 


### PR DESCRIPTION
- Create Repo interface and language color mapping for 28 languages
- Add fetchUserRepos to GitHub service (top 6 by stars, excludes forks)
- Add RepoList component with glass-card grid, topics, stars, and forks
- Integrate repos fetching into page alongside user data